### PR TITLE
User can press 'y' as well as 'Y' to confirm following redirection

### DIFF
--- a/engine/wordpress.py
+++ b/engine/wordpress.py
@@ -81,7 +81,7 @@ class Wordpress:
 	  			print notice("The remote host tried to redirect to: %s" % r.headers['location'])
 	  			user_input = str(raw_input("[?] Do you want to follow the redirection ? [Y]es [N]o, "))
 
-	  			if user_input == "Y":
+	  			if user_input.lower() == "y":
 	  				self.url = r.headers['location']
 
 	  			else:


### PR DESCRIPTION
Small improvement - I've found that 'Y' has to be pressed as confirmation of following redirection. If 'y' is pressed (either intentionally or accidentally) program stops:

```
[?] Do you want to follow the redirection ? [Y]es [N]o
```

I think 'y' should be also accepted as such confirmation.