### PR TITLE
Fixes 'IndexError: list index out of range' in wordpress.py:112 (is_r…

### DIFF
--- a/engine/wordpress.py
+++ b/engine/wordpress.py
@@ -109,7 +109,7 @@ class Wordpress:
 			regex = re.compile(regex)
 			matches = regex.findall(r.text)
 
-			if matches[0] != None and matches[0] != "":
+			if len(matches) > 0 and matches[0] != None and matches[0] != "":
 				self.version = matches[0]
 				print critical("The Wordpress '%s' file exposing a version number: %s" % (self.url+'readme.html', matches[0]))
 


### PR DESCRIPTION
Hi,

This small PR fixes tiny issue I had while using Wordpressscan recently.
Here's output from my console (sorry for URL redacted, but it comes from bug bounty program and I can't disclose it)

```
bl4de:~/hacking/tools/Wordpresscan $ python main.py -u https://www.[REDACTED].com/
_______________________________________________________________
 _    _               _
| |  | |             | |
| |  | | ___  _ __ __| |_ __  _ __ ___  ___ ___  ___ __ _ _ __
| |/\| |/ _ \| '__/ _` | '_ \| '__/ _ \/ __/ __|/ __/ _` | '_ \
\  /\  / (_) | | | (_| | |_) | | |  __/\__ \__ \ (_| (_| | | | |
 \/  \/ \___/|_|  \__,_| .__/|_|  \___||___/___/\___\__,_|_| |_|
                       | |
                       |_|
 WordPress scanner based on wpscan work - @pentest_swissky
_______________________________________________________________
[+] URL: https://www.[REDACTED].com/

[i] The remote host tried to redirect to: https://www.[REDACTED].com/wp-login.php?redirect_to=/
[?] Do you want to follow the redirection ? [Y]es [N]o, y
[]
Traceback (most recent call last):
  File "main.py", line 47, in <module>
    wp = Wordpress(results.url, results.random_agent, results.nocheck)
  File "/Users/bl4de/hacking/tools/Wordpresscan/engine/wordpress.py", line 25, in __init__
    self.is_readme()
  File "/Users/bl4de/hacking/tools/Wordpresscan/engine/wordpress.py", line 112, in is_readme
    if matches[0] != None and matches[0] != "":
IndexError: list index out of range
```

I hope you'll find my PR useful :)

Regards,

bl4de