### PR TITLE
Remove workaround for InsecureRequestWarning

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,6 @@ from engine.wordpress import *
 from engine.scan import *
 from engine.fuzz import *
 from engine.brute import *
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
Fixes #14

> from requests.packages.urllib3.exceptions import InsecureRequestWarning

This used to avoid telling the user that they were using an insecure version of Python.  This workaround is not longer supported because it is not good to ignore that the platform is insecure.  Repeated warnings will push people to upgrade to a secure version of Python. https://stackoverflow.com/questions/27981545/suppress-insecurerequestwarning-unverified-https-request-is-being-made-in-pytho