### PR TITLE
Run flake8 tests on Python 2, Python3, pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+    #- nightly
+    - pypy
+    #- pypy3
+matrix:
+    allow_failures:
+        - python: 3.6
+        - python: nightly
+        - python: pypy
+        - python: pypy3
+install:
+    - pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ You agree that you use this software at your own risk.
 ## Install & Launch
 Dependencies
 ```
-pip install requests
-pip install tornado
-pip install lxml
+pip install -r requirements.txt  # installs lxml, requests, and tornado
 ```
 
 Install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+lxml
+requests
+tornado


### PR DESCRIPTION
 Add free automated flake8 testing of pull requests

The owner of this repo would need to go to https://travis-ci.org/profile and flip the repository switch __on__ to enable free automated flake8 testing of each pull request.

The addition of`requirements.txt`simplifies the issues raised in #13